### PR TITLE
Corrected NHD data error

### DIFF
--- a/rundown.py
+++ b/rundown.py
@@ -217,15 +217,15 @@ for line in reprojects:
 
 
 
-data = [('data\\nhd\\HUC_8.shp', 'huc', '-c', 4926),
-        ('data\\nhd\\HUC_10.shp', 'huc', '-a', 4926),
-        ('data\\nhd\\NHD_Flowlines.shp', 'nhd_flowlines', '-c', 4926),
-        ('data\\nhd\\Gage.shp', 'gages', '-c', 4926),
-        ('data\\nhd\\Catchments.shp', 'catchments', '-c', 4926),
-        ('data\\nhd\\HUC_12.shp', 'huc', '-a', 4926),
-        ('data\\nhd\\NHD_Waterbodies.shp', 'nhd_waterbodies', '-c', 4926),
-        ('data\\nhd\\nhd_p_waterbodies.shp', 'nhdp_waterbodies', '-c', 4926),
-        ('data\\nhd\\NHDP_Flowlines.shp', 'nhdp_flowlines', '-c', 4926)]
+data = [('data\\nhd\\HUC_8.shp', 'huc', '-c', 4269),
+        ('data\\nhd\\HUC_10.shp', 'huc', '-a', 4269),
+        ('data\\nhd\\NHD_Flowlines.shp', 'nhd_flowlines', '-c', 4269),
+        ('data\\nhd\\Gage.shp', 'gages', '-c', 4269),
+        ('data\\nhd\\Catchments.shp', 'catchments', '-c', 4269),
+        ('data\\nhd\\HUC_12.shp', 'huc', '-a', 4269),
+        ('data\\nhd\\NHD_Waterbodies.shp', 'nhd_waterbodies', '-c', 4269),
+        ('data\\nhd\\nhd_p_waterbodies.shp', 'nhdp_waterbodies', '-c', 4269),
+        ('data\\nhd\\NHDP_Flowlines.shp', 'nhdp_flowlines', '-c', 4269)]
 
 for line in data:
     loader(line[0], line[1], line[2], line[3])


### PR DESCRIPTION
Corrected the rundown.py file to ammend an error in the loading of NHD
data.  Data was entered into the database as SRID 4926 before being
reprojected into the group SRID.  Data should have been entered at SRID
4269.  This error caused the data to be displayed as a solig line
instead of a polygon or correct feature type.  Upon loading the
corrected file into a remote server, all features displayed in QGIS in
the correct area and visible as a correct type.